### PR TITLE
Fix npm publish: add --tag latest for date-based versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,6 @@ jobs:
           VERSION=${DATE}-${INT}
           jq ".version = \"$VERSION\"" package.json > package.json.tmp && mv package.json.tmp package.json
 
-          npm publish
+          npm publish --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `--tag latest` to `npm publish` command

The date-based version format (`2026.4.13-1`) has a hyphen that npm interprets as a semver prerelease identifier, causing `npm publish` to fail with "You must specify a tag using --tag when publishing a prerelease version."

## Test plan
- [ ] CI publishes successfully on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)