### PR TITLE
refactor: remove extraContent prop from SiteHeader

### DIFF
--- a/src/lib/SiteHeader.test.tsx
+++ b/src/lib/SiteHeader.test.tsx
@@ -51,8 +51,4 @@ describe("SiteHeader", () => {
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
   });
 
-  it("renders extra content when provided", () => {
-    render(<SiteHeader extraContent={<span>Extra</span>} />);
-    expect(screen.getByText("Extra")).toBeInTheDocument();
-  });
 });

--- a/src/lib/SiteHeader.test.tsx
+++ b/src/lib/SiteHeader.test.tsx
@@ -50,5 +50,4 @@ describe("SiteHeader", () => {
     render(<SiteHeader showThemeToggle={false} />);
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
   });
-
 });

--- a/src/lib/SiteHeader.tsx
+++ b/src/lib/SiteHeader.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from "react";
 import Link from "next/link";
 
 import Logo from "./Logo";
@@ -16,7 +15,6 @@ export interface SiteHeaderProps {
   showThemeToggle?: boolean;
   logoSize?: number;
   logoHref?: string;
-  extraContent?: ReactNode;
 }
 
 export function SiteHeader({
@@ -24,7 +22,6 @@ export function SiteHeader({
   showThemeToggle = true,
   logoSize = 50,
   logoHref = "/",
-  extraContent,
 }: SiteHeaderProps) {
   return (
     <header>
@@ -35,7 +32,6 @@ export function SiteHeader({
           </Link>
         </div>
         <div className="grow" />
-        {extraContent && <div className="px-8">{extraContent}</div>}
         {(showThemeToggle || links.length > 0) && (
           <div className="flex items-center gap-4 px-8">
             {showThemeToggle && <ThemeToggle />}


### PR DESCRIPTION
## Summary

- Removes the `extraContent` prop from `SiteHeader` and `SiteHeaderProps`
- Drops the unused `ReactNode` import
- Removes the corresponding test case

Use the `links` prop to pass additional nav items instead.

Companion PR: icco/natwelch.com#298

## Test plan

- [ ] Run `yarn test` — existing tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)