### PR TITLE
fix: ThemeProvider to cookie storage to eliminate SSR flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,34 @@ A set of common components I use on my sites.
 
 Theme stack is [@wrksz/themes](https://themes.wrksz.dev/) (Next.js 16+); add it as a dependency alongside this package. Import theme primitives from `@icco/react-common` only (no direct `@wrksz/themes` imports required):
 
-- **`ThemeProvider`** — `@icco/react-common` or `@icco/react-common/ThemeProvider`; re-export of `@wrksz/themes/next` (async Server Component for root `layout.tsx`).
+- **`ThemeProvider`** — `@icco/react-common` or `@icco/react-common/ThemeProvider`; thin wrapper around `@wrksz/themes/next` (async Server Component for root `layout.tsx`).
 - **`ClientThemeProvider`** / **`useTheme`** — `@icco/react-common` or `@icco/react-common/ClientThemeProvider`; for `"use client"` trees (nested providers, custom toggles).
+
+## Zero-flash defaults
+
+`ThemeProvider` ships with two opinionated defaults that solve the SSR theme flash and the toggle flicker:
+
+- `storage="hybrid"` — the theme is stored in a cookie (so `@wrksz/themes/next` reads it server-side and emits the correct `<html>` class on first paint, eliminating the flash) and mirrored to `localStorage` for cross-tab sync.
+- `disableTransitionOnChange={true}` — suppresses CSS transitions during attribute swaps so the theme toggle is crisp.
+
+Both defaults can be overridden by passing the prop explicitly:
+
+```tsx
+<ThemeProvider storage="localStorage" disableTransitionOnChange={false}>
+  {children}
+</ThemeProvider>
+```
+
+Other supported storage values: `"localStorage"`, `"sessionStorage"`, `"cookie"`, `"none"`. See the [@wrksz/themes API docs](https://themes.wrksz.dev/) for the full prop reference.
+
+Remember to keep `suppressHydrationWarning` on `<html>`:
+
+```tsx
+<html lang="en" suppressHydrationWarning>
+  <body>
+    <ThemeProvider defaultTheme="system" enableSystem>
+      {children}
+    </ThemeProvider>
+  </body>
+</html>
+```

--- a/README.md
+++ b/README.md
@@ -4,34 +4,5 @@ A set of common components I use on my sites.
 
 Theme stack is [@wrksz/themes](https://themes.wrksz.dev/) (Next.js 16+); add it as a dependency alongside this package. Import theme primitives from `@icco/react-common` only (no direct `@wrksz/themes` imports required):
 
-- **`ThemeProvider`** — `@icco/react-common` or `@icco/react-common/ThemeProvider`; thin wrapper around `@wrksz/themes/next` (async Server Component for root `layout.tsx`).
+- **`ThemeProvider`** — `@icco/react-common` or `@icco/react-common/ThemeProvider`; re-export of `@wrksz/themes/next` (async Server Component for root `layout.tsx`).
 - **`ClientThemeProvider`** / **`useTheme`** — `@icco/react-common` or `@icco/react-common/ClientThemeProvider`; for `"use client"` trees (nested providers, custom toggles).
-
-## Zero-flash defaults
-
-`ThemeProvider` ships with two opinionated defaults that solve the SSR theme flash and the toggle flicker:
-
-- `storage="hybrid"` — the theme is stored in a cookie (so `@wrksz/themes/next` reads it server-side and emits the correct `<html>` class on first paint, eliminating the flash) and mirrored to `localStorage` for cross-tab sync.
-- `disableTransitionOnChange={true}` — suppresses CSS transitions during attribute swaps so the theme toggle is crisp.
-
-Both defaults can be overridden by passing the prop explicitly:
-
-```tsx
-<ThemeProvider storage="localStorage" disableTransitionOnChange={false}>
-  {children}
-</ThemeProvider>
-```
-
-Other supported storage values: `"localStorage"`, `"sessionStorage"`, `"cookie"`, `"none"`. See the [@wrksz/themes API docs](https://themes.wrksz.dev/) for the full prop reference.
-
-Remember to keep `suppressHydrationWarning` on `<html>`:
-
-```tsx
-<html lang="en" suppressHydrationWarning>
-  <body>
-    <ThemeProvider defaultTheme="system" enableSystem>
-      {children}
-    </ThemeProvider>
-  </body>
-</html>
-```

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ A set of common components I use on my sites.
 
 Theme stack is [@wrksz/themes](https://themes.wrksz.dev/) (Next.js 16+); add it as a dependency alongside this package. Import theme primitives from `@icco/react-common` only (no direct `@wrksz/themes` imports required):
 
-- **`ThemeProvider`** — `@icco/react-common` or `@icco/react-common/ThemeProvider`; re-export of `@wrksz/themes/next` (async Server Component for root `layout.tsx`).
+- **`ThemeProvider`** — `@icco/react-common` or `@icco/react-common/ThemeProvider`; thin wrapper around `@wrksz/themes/next` (async Server Component for root `layout.tsx`). Defaults `storage="hybrid"` and `disableTransitionOnChange` to avoid SSR theme flash; pass either prop to override.
 - **`ClientThemeProvider`** / **`useTheme`** — `@icco/react-common` or `@icco/react-common/ClientThemeProvider`; for `"use client"` trees (nested providers, custom toggles).

--- a/src/lib/ThemeProvider.tsx
+++ b/src/lib/ThemeProvider.tsx
@@ -1,7 +1,28 @@
+import {
+  type DefaultTheme,
+  ThemeProvider as WrkszThemeProvider,
+  type ThemeProviderProps,
+} from "@wrksz/themes/next";
+
 /**
  * Async Server Component for Next.js root layouts. Do not import this entry from a file
  * marked `"use client"` — use `ClientThemeProvider` from `@wrksz/themes/client` instead.
  *
+ * Defaults `storage="hybrid"` so the server reads the theme cookie and emits the correct
+ * `<html>` class on first paint (no flash), with a `localStorage` mirror for cross-tab sync.
+ * Defaults `disableTransitionOnChange={true}` to avoid CSS transition flicker during toggles.
+ * Either default can be overridden by passing the prop explicitly.
+ *
  * @see https://themes.wrksz.dev
  */
-export { ThemeProvider } from "@wrksz/themes/next";
+export function ThemeProvider<Themes extends string = DefaultTheme>(
+  props: ThemeProviderProps<Themes>
+) {
+  return (
+    <WrkszThemeProvider<Themes>
+      storage="hybrid"
+      disableTransitionOnChange
+      {...props}
+    />
+  );
+}

--- a/src/lib/ThemeProvider.tsx
+++ b/src/lib/ThemeProvider.tsx
@@ -5,13 +5,9 @@ import {
 } from "@wrksz/themes/next";
 
 /**
- * Async Server Component for Next.js root layouts. Do not import this entry from a file
- * marked `"use client"` — use `ClientThemeProvider` from `@wrksz/themes/client` instead.
- *
- * Defaults `storage="hybrid"` so the server reads the theme cookie and emits the correct
- * `<html>` class on first paint (no flash), with a `localStorage` mirror for cross-tab sync.
- * Defaults `disableTransitionOnChange={true}` to avoid CSS transition flicker during toggles.
- * Either default can be overridden by passing the prop explicitly.
+ * Async Server Component for Next.js root layouts. Wraps `@wrksz/themes/next`
+ * with `storage="hybrid"` and `disableTransitionOnChange` defaults to avoid
+ * SSR theme flash. Override either by passing the prop.
  *
  * @see https://themes.wrksz.dev
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,9 +928,9 @@ assertion-error@^2.0.1:
   integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 baseline-browser-mapping@^2.9.19:
-  version "2.10.23"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz#3a1a55d1a691a8c8d74688af7f1fd17eac23c184"
-  integrity sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==
+  version "2.10.24"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz#6dc320c7bf53859ec2bf55d54db6d2e5c078df16"
+  integrity sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==
 
 bidi-js@^1.0.3:
   version "1.0.3"
@@ -1678,9 +1678,9 @@ tinyexec@^0.3.2:
   integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
 
 tinyexec@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.1.1.tgz#e1ff45dfa60d1dedb91b734956b78f6c2a3e821b"
-  integrity sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.1.2.tgz#11feef204b706d4668ca4013db29f3bd64f5c4dc"
+  integrity sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==
 
 tinyglobby@^0.2.11, tinyglobby@^0.2.15, tinyglobby@^0.2.16:
   version "0.2.16"
@@ -1695,17 +1695,17 @@ tinyrainbow@^3.1.0:
   resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz#1d8a623893f95cf0a2ddb9e5d11150e191409421"
   integrity sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==
 
-tldts-core@^7.0.28:
-  version "7.0.28"
-  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-7.0.28.tgz#28c256edae2ed177b2a8338a51caf81d41580ecf"
-  integrity sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==
+tldts-core@^7.0.29:
+  version "7.0.29"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-7.0.29.tgz#c3806f5af57b0351ed9415899be2a8dafa3f56dc"
+  integrity sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==
 
 tldts@^7.0.5:
-  version "7.0.28"
-  resolved "https://registry.yarnpkg.com/tldts/-/tldts-7.0.28.tgz#5a5bb26ef3f70008d88c6e53ff58cd59ed8d4c68"
-  integrity sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==
+  version "7.0.29"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-7.0.29.tgz#5a246d4ffcdf8b34cd9cc2dea424162a653f69d1"
+  integrity sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==
   dependencies:
-    tldts-core "^7.0.28"
+    tldts-core "^7.0.29"
 
 tough-cookie@^6.0.1:
   version "6.0.1"
@@ -1765,9 +1765,9 @@ typescript@^6.0.2:
   integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 ufo@^1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.3.tgz#799666e4e88c122a9659805e30b9dc071c3aed4f"
-  integrity sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.4.tgz#7a8fb875fcc6382d2c7d0b3692738b0500a92467"
+  integrity sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==
 
 undici-types@^7.21.0:
   version "7.25.0"


### PR DESCRIPTION
Wraps `@wrksz/themes/next` with `storage="hybrid"` and `disableTransitionOnChange` defaults so SSR reads the theme cookie and emits the right `<html>` class on first paint. Fixes the post-refactor theme flash on consumer sites. Either default can be overridden via props.