### PR TITLE
fix: default ThemeProvider attribute to data-theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ A set of common components I use on my sites.
 
 Theme stack is [@wrksz/themes](https://themes.wrksz.dev/) (Next.js 16+); add it as a dependency alongside this package. Import theme primitives from `@icco/react-common` only (no direct `@wrksz/themes` imports required):
 
-- **`ThemeProvider`** — `@icco/react-common` or `@icco/react-common/ThemeProvider`; thin wrapper around `@wrksz/themes/next` (async Server Component for root `layout.tsx`). Defaults `storage="hybrid"` and `disableTransitionOnChange` to avoid SSR theme flash; pass either prop to override.
+- **`ThemeProvider`** — `@icco/react-common` or `@icco/react-common/ThemeProvider`; thin wrapper around `@wrksz/themes/next` (async Server Component for root `layout.tsx`). Defaults `attribute="data-theme"` (matches daisyUI/Tailwind `[data-theme=*]`), `storage="hybrid"`, and `disableTransitionOnChange` to avoid SSR theme flash; pass any prop to override.
 - **`ClientThemeProvider`** / **`useTheme`** — `@icco/react-common` or `@icco/react-common/ClientThemeProvider`; for `"use client"` trees (nested providers, custom toggles).

--- a/src/lib/ThemeProvider.tsx
+++ b/src/lib/ThemeProvider.tsx
@@ -6,8 +6,10 @@ import {
 
 /**
  * Async Server Component for Next.js root layouts. Wraps `@wrksz/themes/next`
- * with `storage="hybrid"` and `disableTransitionOnChange` defaults to avoid
- * SSR theme flash. Override either by passing the prop.
+ * with `attribute="data-theme"`, `storage="hybrid"`, and
+ * `disableTransitionOnChange` defaults to play nicely with daisyUI/Tailwind
+ * `[data-theme=*]` selectors and avoid SSR theme flash. Override any default
+ * by passing the prop.
  *
  * @see https://themes.wrksz.dev
  */
@@ -16,6 +18,7 @@ export function ThemeProvider<Themes extends string = DefaultTheme>(
 ) {
   return (
     <WrkszThemeProvider<Themes>
+      attribute="data-theme"
       storage="hybrid"
       disableTransitionOnChange
       {...props}


### PR DESCRIPTION
Default `ThemeProvider` `attribute` to `data-theme` so daisyUI's `[data-theme=*]` selectors and the `@custom-variant dark (... [data-theme=dark] ...)` rule used across consumer sites actually receive the cookie/toggle. Pass `attribute="class"` to opt out.