### PR TITLE
feat(SiteHeader): add showLogo + children slot

### DIFF
--- a/src/lib/SiteHeader.tsx
+++ b/src/lib/SiteHeader.tsx
@@ -13,26 +13,36 @@ export interface NavLink {
 export interface SiteHeaderProps {
   links?: NavLink[];
   showThemeToggle?: boolean;
+  showLogo?: boolean;
   logoSize?: number;
   logoHref?: string;
+  /** Extra content rendered on the right after the theme toggle and links
+   *  (e.g. a user menu in product apps). */
+  children?: React.ReactNode;
 }
 
 export function SiteHeader({
   links = [],
   showThemeToggle = true,
+  showLogo = true,
   logoSize = 50,
   logoHref = "/",
+  children,
 }: SiteHeaderProps) {
+  const hasRightContent =
+    showThemeToggle || links.length > 0 || children !== undefined;
   return (
     <header>
       <nav className="flex items-center py-8">
-        <div className="flex-none">
-          <Link href={logoHref}>
-            <Logo size={logoSize} className="logo stroke-current px-8" />
-          </Link>
-        </div>
+        {showLogo && (
+          <div className="flex-none">
+            <Link href={logoHref}>
+              <Logo size={logoSize} className="logo stroke-current px-8" />
+            </Link>
+          </div>
+        )}
         <div className="grow" />
-        {(showThemeToggle || links.length > 0) && (
+        {hasRightContent && (
           <div className="flex items-center gap-4 px-8">
             {showThemeToggle && <ThemeToggle />}
             {links.map(({ name, href, prefetch, className }) => (
@@ -45,6 +55,7 @@ export function SiteHeader({
                 {name}
               </Link>
             ))}
+            {children}
           </div>
         )}
       </nav>


### PR DESCRIPTION
Adds `showLogo` (default `true`) and a `children` slot to `SiteHeader` so a product app can hide the personal logo and inject a user menu on the right alongside the theme toggle and links. No behavior change for existing call sites.