### PR TITLE
feat(SiteHeader): add brand slot for custom left-side branding

### DIFF
--- a/src/lib/SiteHeader.test.tsx
+++ b/src/lib/SiteHeader.test.tsx
@@ -50,4 +50,19 @@ describe("SiteHeader", () => {
     render(<SiteHeader showThemeToggle={false} />);
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
   });
+
+  it("renders a custom brand element in place of the default logo", () => {
+    render(<SiteHeader brand={<span>MyBrand</span>} />);
+    expect(screen.getByText("MyBrand")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "" })).not.toBeInTheDocument();
+  });
+
+  it("renders custom children on the right", () => {
+    render(
+      <SiteHeader>
+        <span>RightSlot</span>
+      </SiteHeader>
+    );
+    expect(screen.getByText("RightSlot")).toBeInTheDocument();
+  });
 });

--- a/src/lib/SiteHeader.tsx
+++ b/src/lib/SiteHeader.tsx
@@ -16,6 +16,10 @@ export interface SiteHeaderProps {
   showLogo?: boolean;
   logoSize?: number;
   logoHref?: string;
+  /** Custom brand element rendered on the left in place of the default Logo
+   *  (e.g. a wordmark for a product app). When provided, `showLogo`,
+   *  `logoSize`, and `logoHref` are ignored. */
+  brand?: React.ReactNode;
   /** Extra content rendered on the right after the theme toggle and links
    *  (e.g. a user menu in product apps). */
   children?: React.ReactNode;
@@ -27,6 +31,7 @@ export function SiteHeader({
   showLogo = true,
   logoSize = 50,
   logoHref = "/",
+  brand,
   children,
 }: SiteHeaderProps) {
   const hasRightContent =
@@ -34,13 +39,15 @@ export function SiteHeader({
   return (
     <header>
       <nav className="flex items-center py-8">
-        {showLogo && (
+        {brand ? (
+          <div className="flex-none px-8">{brand}</div>
+        ) : showLogo ? (
           <div className="flex-none">
             <Link href={logoHref}>
               <Logo size={logoSize} className="logo stroke-current px-8" />
             </Link>
           </div>
-        )}
+        ) : null}
         <div className="grow" />
         {hasRightContent && (
           <div className="flex items-center gap-4 px-8">


### PR DESCRIPTION
Adds a `brand?: ReactNode` prop to `SiteHeader` that renders on the left in place of the default icco `Logo`. When `brand` is set, `showLogo`/`logoSize`/`logoHref` are ignored.

Lets product apps (e.g. robot.villas) reuse `SiteHeader` while keeping their own wordmark.