### PR TITLE
ci: zero-pad release date so versions sort chronologically

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - run: yarn build
       - name: Version and publish
         run: |
-          DATE=$(date +%Y.%-m%-d)
+          DATE=$(date -u +%Y.1%m%d)
           OLDVERSION=$(jq -r ".version" package.json)
           OLDDATE=$(echo $OLDVERSION | sed 's/\.[^.]*$//')
           OLDINT=$(echo $OLDVERSION | sed 's/^.*\.//')


### PR DESCRIPTION
## Summary

- The publish workflow built versions with `date +%Y.%-m%-d`, which strips leading zeros and produced colliding minors that don't sort chronologically (e.g. `2026.430.1` > `2026.53.1`, even though Apr 30 < May 3). Existing tags `v2026.430.3`, `v2026.510.2`, etc. confirm the issue.
- Naive zero-padding (`%Y.%m%d` -> `2026.0510`) is invalid SemVer 2.0.0 (numeric identifiers MUST NOT include leading zeroes), so `node-semver`/`npm publish` would reject or normalize it.
- Switched to `date -u +%Y.1%m%d`. The literal `1` prefix combined with zero-padded `%m%d` yields a fixed-width 5-digit minor (`10101`..`11231`) that:
  - never has a leading zero (always starts with `1`), so it stays valid SemVer;
  - sorts numerically in chronological order;
  - preserves the existing `YEAR.MINOR.INT` shape, so `OLDDATE`/`OLDINT` parsing, the `INT` increment, `npm publish`, and `git tag v\${VERSION}` all keep working unchanged.
- Also switched to UTC to avoid runner timezone drift.

| Date | Old (broken) | New |
|---|---|---|
| Jan 1 | `2026.11` | `2026.10101` |
| Apr 30 | `2026.430` | `2026.10430` |
| May 3 | `2026.53` | `2026.10503` |
| May 10 | `2026.510` | `2026.10510` |
| Dec 31 | `2026.1231` | `2026.11231` |
