### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   "scripts": {
     "start": "tsup --watch",
     "lint": "prettier --write '**/*.{ts,tsx,css,yml,yaml,json}'",
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json && node scripts/copy-dcts.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1195,11 +1195,6 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2412,8 +2407,6 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.15: {}
-
   nanoid@3.3.16: {}
 
   next@16.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
@@ -2476,7 +2469,7 @@ snapshots:
 
   postcss@8.5.16:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/scripts/copy-dcts.mjs
+++ b/scripts/copy-dcts.mjs
@@ -1,0 +1,16 @@
+// Copy each dist/**/*.d.ts to a .d.cts sibling for CJS consumers.
+import { readdirSync, copyFileSync } from "node:fs";
+import { join } from "node:path";
+
+function walk(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const file = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(file);
+    } else if (file.endsWith(".d.ts")) {
+      copyFileSync(file, file.slice(0, -".d.ts".length) + ".d.cts");
+    }
+  }
+}
+
+walk("dist");

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "rootDir": "src"
+  },
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts"]
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,7 +19,9 @@ export default defineConfig({
     "src/lib/SiteHeader.tsx",
   ],
   format: ["esm", "cjs"],
-  dts: true,
+  // Declarations are emitted by tsc (see the build script); tsup's dts
+  // support (rollup-plugin-dts) is incompatible with TypeScript 7.
+  dts: false,
   splitting: false,
   clean: true,
   bundle: false,


### PR DESCRIPTION
- typescript ^6.0.3 → ^7.0.2 (also lands Dependabot #131 from main). TS7's native compiler drops the JS compiler API that tsup/rollup-plugin-dts used for dts generation, so declarations are now emitted via `tsc -p tsconfig.build.json --emitDeclarationOnly` with a small script copying `.d.ts` to `.d.cts` siblings; tsup handles JS only.
- Deduped transitive nanoid 3.3.15 → 3.3.16 in the lockfile.
- All other direct deps already at latest per `pnpm outdated`.
- depcheck: no unused dependencies found.