### PR TITLE
fix: publish version collisions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,10 @@ jobs:
           fi
 
           VERSION=${DATE}.${INT}
+          while npm view "@icco/react-common@${VERSION}" version >/dev/null 2>&1; do
+            INT=$((INT + 1))
+            VERSION=${DATE}.${INT}
+          done
           jq ".version = \"$VERSION\"" package.json > package.json.tmp && mv package.json.tmp package.json
 
           npm publish
@@ -46,6 +50,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json
           git diff --quiet --staged || git commit -m "chore: bump version to $(jq -r .version package.json) [skip ci]"
+          git pull --rebase origin main
           VERSION=$(jq -r .version package.json)
           git tag "v${VERSION}"
           git push

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icco/react-common",
-  "version": "2026.10713.4",
+  "version": "2026.10720.1",
   "type": "module",
   "packageManager": "pnpm@11.15.0",
   "private": false,


### PR DESCRIPTION
Publish has failed on the last 4 pushes to main: the 02:56 run published 2026.10720.1 but lost the version-bump push race to the dependabot merges, so every later run recomputed 2026.10720.1 and npm rejected it.

- Rebase onto main before pushing the version bump
- Skip versions already in the registry when computing the next version
- Set package.json to 2026.10720.1 (published this morning, never committed; tag pushed retroactively)

Merging this will publish current main as 2026.10720.2.